### PR TITLE
Added a separate path for surefire junit

### DIFF
--- a/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/SwiftPlugin.java
+++ b/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/SwiftPlugin.java
@@ -17,8 +17,7 @@
  */
 package org.sonar.plugins.swift;
 
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
 import org.sonar.api.Properties;
 import org.sonar.api.Property;
 import org.sonar.api.SonarPlugin;
@@ -37,7 +36,7 @@ import org.sonar.plugins.swift.issues.tailor.TailorSensor;
 import org.sonar.plugins.swift.lang.core.Swift;
 import org.sonar.plugins.swift.surefire.SwiftSurefireSensor;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 
 @Properties({
         @Property(
@@ -65,6 +64,13 @@ import com.google.common.collect.ImmutableList;
                 key = LizardSensor.REPORT_PATH_KEY,
                 defaultValue = LizardSensor.DEFAULT_REPORT_PATH,
                 name = "Path to lizard report",
+                description = "Relative to projects' root.",
+                global = false,
+                project = true),
+        @Property(
+                key = SwiftSurefireSensor.REPORTS_PATH_KEY,
+                defaultValue = SwiftSurefireSensor.DEFAULT_REPORTS_PATH,
+                name = "Path to surefire junit report",
                 description = "Relative to projects' root.",
                 global = false,
                 project = true)

--- a/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/surefire/SwiftSurefireSensor.java
+++ b/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/surefire/SwiftSurefireSensor.java
@@ -27,6 +27,7 @@ import org.sonar.api.component.ResourcePerspectives;
 import org.sonar.api.config.Settings;
 import org.sonar.api.resources.Project;
 import org.sonar.api.scan.filesystem.PathResolver;
+import org.sonar.plugins.swift.SwiftPlugin;
 
 import java.io.File;
 
@@ -34,7 +35,7 @@ public final class SwiftSurefireSensor implements Sensor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SwiftSurefireSensor.class);
 
-    public static final String REPORTS_PATH_KEY = "sonar.junit.reportsPath";
+    public static final String REPORTS_PATH_KEY = SwiftPlugin.PROPERTY_PREFIX + "swiftsurefire.junit.reportsPath";
     public static final String DEFAULT_REPORTS_PATH = "sonar-reports/";
 
 


### PR DESCRIPTION
In order to avoid conflicts with java projects, a separate path has been
introduced for surefire junit reports.