### PR TITLE
added `--no-color` to `sonar.swift.tailor.config`

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -109,4 +109,4 @@ sonar.swift.excludedPathsFromCoverage=.*Tests.*
 #    --max-severity=<error|warning (default)>   maximum severity
 #    --max-struct-length=<0-999>                maximum Struct length (in lines)
 #    --min-name-length=<1-999>                  minimum Identifier name length (in characters)
-sonar.swift.tailor.config=--max-line-length=100 --max-file-length=500 --max-name-length=40 --max-name-length=40 --min-name-length=4
+sonar.swift.tailor.config=--no-color --max-line-length=100 --max-file-length=500 --max-name-length=40 --max-name-length=40 --min-name-length=4


### PR DESCRIPTION
- as default use `--no-color` for tailor in order to get clean logs (otherwise nothing gets parsed)
- also fixes #121